### PR TITLE
zip warning in readFAO_online = error

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '2499840'
+ValidationKey: '2525000'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -35,15 +35,6 @@ jobs:
           # gms, goxygen, GDPuc) will usually have an outdated binary version
           # available; by using extra-packages we get the newest version
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
-
-      - name: Install python dependencies if applicable
-        run: |
-          [ -f requirements.txt ] && python -m pip install --upgrade pip wheel || true
-          [ -f requirements.txt ] && pip install -r requirements.txt || true
-
       - name: Run pre-commit checks
         shell: bash
         run: |

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ type: software
 title: |-
   mrfaocore: madrat-based package providing core FAO-related preprocessing
       functions
-version: 1.2.4
-date-released: '2025-03-13'
+version: 1.2.5
+date-released: '2025-04-22'
 abstract: This madrat-based package provides core FAO-related preprocessing functions.
 authors:
 - family-names: Chen

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: mrfaocore
 Title: madrat-based package providing core FAO-related preprocessing
     functions
-Version: 1.2.4
-Date: 2025-03-13
+Version: 1.2.5
+Date: 2025-04-22
 Authors@R: c(
     person("David", "Chen", , "david.chen@pik-potsdam.de", role = c("aut", "cre")),
     person("Ulrich", "Kreidenweis", role = "aut"),

--- a/R/readFAO_online.R
+++ b/R/readFAO_online.R
@@ -127,7 +127,9 @@ readFAO_online <- function(subtype) { # nolint
       break
     } else if (extension == "zip" && file.exists(file)) {
       tempfolder <- local_tempdir()
-      unzip(file, exdir = tempfolder)
+      tryCatch({
+        unzip(file, exdir = tempfolder)
+      }, warning = stop)
       file <- file.path(tempfolder, csvName)
       break
     }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # madrat-based package providing core FAO-related preprocessing
     functions
 
-R package **mrfaocore**, version **1.2.4**
+R package **mrfaocore**, version **1.2.5**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/mrfaocore)](https://cran.r-project.org/package=mrfaocore) [![R build status](https://github.com/pik-piam/mrfaocore/workflows/check/badge.svg)](https://github.com/pik-piam/mrfaocore/actions) [![codecov](https://codecov.io/gh/pik-piam/mrfaocore/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/mrfaocore) [![r-universe](https://pik-piam.r-universe.dev/badges/mrfaocore)](https://pik-piam.r-universe.dev/builds)
 
@@ -40,7 +40,7 @@ In case of questions / problems please contact David Chen <david.chen@pik-potsda
 
 To cite package **mrfaocore** in publications use:
 
-Chen D, Kreidenweis U, Mishra A, Karstens K, Leon Bodirsky B, Leip D, Stevanovic M, Leon Bodrisky B, Klein D, Molina Bacca E (2025). "mrfaocore: madrat-based package providing core FAO-related preprocessing functions." Version: 1.2.4, <https://github.com/pik-piam/mrfaocore>.
+Chen D, Kreidenweis U, Mishra A, Karstens K, Leon Bodirsky B, Leip D, Stevanovic M, Leon Bodrisky B, Klein D, Molina Bacca E (2025). "mrfaocore: madrat-based package providing core FAO-related preprocessing functions." Version: 1.2.5, <https://github.com/pik-piam/mrfaocore>.
 
 A BibTeX entry for LaTeX users is
 
@@ -49,9 +49,9 @@ A BibTeX entry for LaTeX users is
   title = {mrfaocore: madrat-based package providing core FAO-related preprocessing
     functions},
   author = {David Chen and Ulrich Kreidenweis and Abhijeet Mishra and Kristine Karstens and Benjamin {Leon Bodirsky} and Debbora Leip and Mishko Stevanovic and Benjamin {Leon Bodrisky} and David Klein and Edna {Molina Bacca}},
-  date = {2025-03-13},
+  date = {2025-04-22},
   year = {2025},
   url = {https://github.com/pik-piam/mrfaocore},
-  note = {Version: 1.2.4},
+  note = {Version: 1.2.5},
 }
 ```


### PR DESCRIPTION
We had the warning below come up a couple times, leading to a faulty cache file being written (some countries, e.g. SUN were missing). I was not able to reproduce it, but this PR should prevent such a cache file from being written in the future.
```
~~~~~~~~~ Run readSource(type = "FAO_online", subtype = "FSCrop")
~~~~~~~~~~ WARNING: write error in extracting from zip file
~~~~~~~~~~ WARNING: Discarded single-line footer: <<"229","Uni>>
~~~~~~~~~~  - done writing cache readFAO_online-F2ba676ea-0c6e87ee.rds
```